### PR TITLE
Automagically copy ./mods and ./runtime to the output directory.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,7 @@ jobs:
         working-directory: ./Lawrence
         run: >
           dotnet publish -c Release -f net7.0 -r linux-x64 --self-contained -p:PublishSingleFile=true -o bin/publish/linux-x64 &&
-          cd bin/publish/linux-x64 && 
-          cp -R ../../../mods ../../../runtime . &&
+          cd bin/publish/linux-x64 &&
           zip Lawrence-linux-x64.zip -r .
         
       - name: Create release

--- a/Lawrence/Lawrence.csproj
+++ b/Lawrence/Lawrence.csproj
@@ -31,4 +31,12 @@
     <Folder Include="UI\" />
     <Folder Include="runtime\" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="mods\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="runtime\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/Lawrence/Player.cs
+++ b/Lawrence/Player.cs
@@ -160,6 +160,9 @@ namespace Lawrence
             SendPacket(Packet.MakeUnlockLevelPacket(level));
         }
 
+        public void WriteAddressValue(uint address, uint value) {
+            SendPacket(Packet.MakeSetAddressValuePacket(address, value));
+        }
     }
     #endregion
 

--- a/Lawrence/Player.cs
+++ b/Lawrence/Player.cs
@@ -160,9 +160,6 @@ namespace Lawrence
             SendPacket(Packet.MakeUnlockLevelPacket(level));
         }
 
-        public void WriteAddressValue(uint address, uint value) {
-            SendPacket(Packet.MakeSetAddressValuePacket(address, value));
-        }
     }
     #endregion
 


### PR DESCRIPTION
This change will automatically copy the `mods` and `runtime` folders to the output.