### PR TITLE
implemented client communication flags can be set from player object

### DIFF
--- a/Lawrence/Core/Packet.cs
+++ b/Lawrence/Core/Packet.cs
@@ -63,6 +63,7 @@ public enum MPStateType : ushort
     MP_STATE_TYPE_UNLOCK_LEVEL = 14,
     MP_STATE_TYPE_LEVEL_FLAG = 15,
     MP_STATE_TYPE_UNLOCK_SKILLPOINT = 16,
+    MP_STATE_SET_COMMUNICATION_FLAGS = 17,
 }
 
 public enum MPDamageFlags : uint {
@@ -1126,6 +1127,19 @@ public static Packet MakeMobyUpdatePacket(ushort id, Moby moby) {
             packet.AddBodyPart(setLevelFlag);
         }
 
+        return packet;
+    }
+
+    public static Packet MakeSetCommunicationFlagsPacket(UInt32 bitmap) {
+        var packet = new Packet(MPPacketType.MP_PACKET_SET_STATE);
+        
+        MPPacketSetState setCommunicationFlags = new MPPacketSetState {
+            StateType = MPStateType.MP_STATE_SET_COMMUNICATION_FLAGS,
+            Value = bitmap
+        };
+        
+        packet.AddBodyPart(setCommunicationFlags);
+        
         return packet;
     }
 

--- a/Lawrence/Game/Player.cs
+++ b/Lawrence/Game/Player.cs
@@ -293,6 +293,10 @@ partial class Player {
         }
     }
 
+    public void setCommunicationFlags(UInt32 bitmap) {
+        SendPacket(Packet.MakeSetCommunicationFlagsPacket(bitmap));
+    }
+
     public void ShowErrorMessage(string message) {
         _client.ShowErrorMessage(message);
     }

--- a/Lawrence/mods/randomizer/Lobby/LobbyUniverse.lua
+++ b/Lawrence/mods/randomizer/Lobby/LobbyUniverse.lua
@@ -14,6 +14,7 @@ function LobbyUniverse:OnPlayerJoin(player)
     --player:LoadLevel("KaleboIII")
     player:LoadLevel("Veldin1")
     player:Make(LobbyPlayer)
+    player:setCommunicationFlags(Player.communicationFlags.ENABLE_ALL - Player.communicationFlags.ENABLE_ON_UNLOCK_ITEM)
 end
 
 function LobbyUniverse:OnTick()

--- a/Lawrence/runtime/lib/Player.lua
+++ b/Lawrence/runtime/lib/Player.lua
@@ -14,6 +14,15 @@ Player.offset = {
     gildedItems = 0x969ca8,
 }
 
+Player.communicationFlags = {
+    ENABLE_ON_UNLOCK_ITEM     =0x00000001,
+    ENABLE_ON_UNLOCK_LEVEL    =0x00000002,
+    ENABLE_ON_PICKUP_GOLD_BOLT=0x00000004,
+    ENABLE_ON_GET_BOLTS       =0x00000008,
+
+    ENABLE_ALL=                0xffffffff
+}
+
 function Player:initialize(internalEntity)
     Entity.initialize(self, internalEntity)
 end


### PR DESCRIPTION
implemented the option to set communication flags on a player object.
details about communication flags detailed in client pull request.

Changes stable without matching client changes